### PR TITLE
Bug fixes for resolving pinchouts

### DIFF
--- a/src/io/MESH_ReadExodusII_Serial.c
+++ b/src/io/MESH_ReadExodusII_Serial.c
@@ -878,6 +878,7 @@ extern "C" {
               if (MSTK_VLen3(fnormal[k]) < 1.0e-15) {
                 if(!MEnt_IsMarked(rfarr[k], mkfid)) {
                   MEnt_Mark(rfarr[k], mkfid);
+                  rfdirs[k] = 1;
                 }
                 else {
                   List_ptr fregs = MF_Regions(rfarr[k]);
@@ -885,6 +886,7 @@ extern "C" {
                     MSTK_Report(funcname,"Face already connected to two regions",MSTK_FATAL);
                   
                   List_Delete(fregs);
+                  rfdirs[k] = 0;
                 }
               }
               else {

--- a/src/mod/ME_Collapse.c
+++ b/src/mod/ME_Collapse.c
@@ -272,6 +272,8 @@ MVertex_ptr ME_Collapse(MEdge_ptr e, MVertex_ptr vkeep_in, int topoflag,
 	for (i = 0; i < nrf; i++) {
 
 	  rface1 = List_Entry(rfaces,i);
+    if (MEnt_Dim(rface1) == MDELETED)
+      continue;
 	
 	  fverts1 = MF_Vertices(rface1,1,0);
 	  nfv1 = List_Num_Entries(fverts1);
@@ -279,6 +281,8 @@ MVertex_ptr ME_Collapse(MEdge_ptr e, MVertex_ptr vkeep_in, int topoflag,
 	  for (j = i+1; j < nrf; j++) {
 	  
 	    rface2 = List_Entry(rfaces,j);
+      if (MEnt_Dim(rface2) == MDELETED)
+        continue;
 
 	    fverts2 = MF_Vertices(rface2,1,0);
 	    nfv2 = List_Num_Entries(fverts2);


### PR DESCRIPTION
In ME_Collapse.c:
Some regions could be mistakenly labeled as degenerate. Say, we deleted a face, then replaced the removed vertex index with that of a kept one, and now that face has vertices with IDs 4,10,10. If in the list of region's faces this deleted face is listed after, say, face with vertices 1,4,10, then two faces will be mistakenly considered identical.
Fix: skip deleted faces when checking faces for being identical.

MESH_ReadExodusII_Serial.c:
The "direction" of degenerate faces with respect to region is determined based on the direction of adjacent non-degenerate faces from the same region and is written into regions' connectivity. In the case of degenerate cell, it's possible to have the same direction with respect to both adjacent regions, this fix makes sure both regions are listed in face's connectivity (order doesn't really matter). This removes an error message triggered when we delete a region connected to a degenerate face, but not listed as its connected region.
