### PR TITLE
Bugfix for non-empty faces of empty regions

### DIFF
--- a/src/io/MESH_ReadExodusII_Serial.c
+++ b/src/io/MESH_ReadExodusII_Serial.c
@@ -895,9 +895,25 @@ extern "C" {
                 
             double outvec[3], dp;
             MSTK_VDiff3(fcen[k],rcen,outvec);
-                
-            dp = MSTK_VDot3(outvec,fnormal[k]);
-            rfdirs[k] = (dp > 0) ? 1 : 0;
+
+            List_ptr fregs = MF_Regions(rfarr[k]);
+            if (MSTK_VLen3(outvec) < 1.0e-15) {
+              if (!fregs)
+                rfdirs[k] = 1;
+              else {
+                MRegion_ptr adjreg = List_Entry(fregs, 0);
+                rfdirs[k] = !MR_FaceDir(adjreg, rfarr[k]);
+              }
+            }
+            else {                
+              dp = MSTK_VDot3(outvec,fnormal[k]);
+              rfdirs[k] = (dp > 0) ? 1 : 0;
+              if (fregs) {
+                MRegion_ptr adjreg = List_Entry(fregs, 0);
+                if (rfdirs[k] == MR_FaceDir(adjreg, rfarr[k]))
+                  MF_Add_Region(rfarr[k], adjreg, rfdirs[k]);
+              }
+            }
           }
             }
 


### PR DESCRIPTION
For empty regions, the vector from the center of the region to the center of the non-empty face can have zero length, thus its dot product with the face normal is zero. This is a problem for non-empty faces, as empty regions can add themselves to the face connectivity information at the incorrect position (wrong direction). If the face is to be deleted (after merging), it at worst generates an error message with no consequences. If the face is also connected to a non-empty region, which added itself prior to the adjacent empty one, the face connectivity information might be no longer correct.
