### PR TITLE
Add a global ID renumbering capability

### DIFF
--- a/include/MSTK.h
+++ b/include/MSTK.h
@@ -193,6 +193,8 @@ void MSTK_Init(void);
                 = 1 --- renumbering using Reverse Cuthill-McKee algorithm 
      mtype      = Type of entity to renumber (MVERTEX, MEDGE, MFACE, MREGION
                   or MALLTYPE)
+
+                  WORKS ONLY FOR SERIAL MESHES - See Mesh_RenumberGlobalIDs
   */
 
   void        MESH_Renumber(Mesh_ptr mesh, int renum_type, MType mtype);
@@ -268,6 +270,7 @@ void MSTK_Init(void);
 
   int         MESH_Parallel_Check(Mesh_ptr mesh, MSTK_Comm comm);
 
+  /* Query Global IDs */
 
   MVertex_ptr MESH_VertexFromGlobalID(Mesh_ptr mesh, int global_id);
   MEdge_ptr   MESH_EdgeFromGlobalID(Mesh_ptr mesh, int global_id);
@@ -275,6 +278,15 @@ void MSTK_Init(void);
   MRegion_ptr MESH_RegionFromGlobalID(Mesh_ptr mesh, int global_id);
   MEntity_ptr MESH_EntityFromGlobalID(Mesh_ptr mesh, MType mtype, int i);
 
+  /* Renumber global IDs in a parallel mesh */
+  /* If mtype = MALLTYPE, all entity types are renumbered and made contiguous */
+  /* Only method = 0 (sequential) is supported for now                        */
+  /* Eventually, one could precompute some global IDs and just send it        */
+  /* to this routine (NOT IMPLEMENTED)                                        */
+  /* Cannot use mtype = MALLTYPE for preassigned GIDs                             */
+
+  int         MESH_Renumber_GlobalIDs(Mesh_ptr mesh, MType mtype, int method,
+                                      int *preassigned_gids, MSTK_Comm comm);
 
   /* Get a partitioning for mesh using METIS (method=1) or ZOLTAN (method=2) */
   /* Doesn't actually partition the mesh or distribute it                    */

--- a/src/par/MESH_AssignGlobalIDs.c
+++ b/src/par/MESH_AssignGlobalIDs.c
@@ -12,11 +12,18 @@ extern "C" {
 
 
   /* 
-     This function is a collective call
-     It assigns each submesh the global IDs of vertices, edges, faces and regions
-     It assumes no additional information at all
+     THIS IS AN INTERNAL MSTK CALL THAT SHOULD ***ONLY*** BE USED AS
+     ONE STEP IN A SERIES OF WELL COORDINATED STEPS DURING
+     DISTRIBUTING A MESH FROM ONE PROCESSOR TO MANY.
 
-     It also assign the proper master partition id and ptype
+     Assign global IDs of vertices (by comparing coordinates, if not
+     already given), and use global IDs of vertices to match up and
+     assign global IDs of edges, faces and regions on each
+     partition. Also assign the proper master partition ID and
+     parallel type for entities on the parallel boundary.
+
+     At this stage, there are no ghost layers and the partitions are
+     not in their final state.
 
      Author(s): Duo Wang, Rao Garimella
   */

--- a/src/par/MESH_AssignGlobalIDs_point.c
+++ b/src/par/MESH_AssignGlobalIDs_point.c
@@ -11,12 +11,22 @@ extern "C" {
 
 
   /* 
-     This function is a collective call
-     It assigns each submesh the global IDs of vertices, edges, faces and regions
+     THIS IS AN INTERNAL MSTK CALL THAT SHOULD ***ONLY*** BE USED AS
+     ONE STEP IN A SERIES OF WELL COORDINATED STEPS DURING
+     DISTRIBUTING A MESH FROM ONE PROCESSOR TO MANY.
 
-     It assumes the parallel neighboring information is already established
+     Assign global IDs of vertices (by comparing coordinates, if not
+     already given), and use global IDs of vertices to match up and
+     assign global IDs of edges, faces and regions on each
+     partition. Also assign the proper master partition ID and
+     parallel type for entities on the parallel boundary.
 
-     If global IDs are already given, skip this function, call MESH_LabelPType()
+     This routine assumes the we know which partitions communicate
+     with each other and therefore, we can use point-to-point
+     communication
+
+     If global IDs are already given, skip this function, call
+     MESH_LabelPType()
 
      Author(s): Duo Wang, Rao Garimella
   */

--- a/src/par/MESH_Renumber_GlobalIDs.c
+++ b/src/par/MESH_Renumber_GlobalIDs.c
@@ -1,0 +1,216 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "MSTK.h"
+#include "MSTK_private.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+  /* 
+     Reassign global IDs to mesh entities to make the contiguous on
+     each partition and numbered according to some scheme. Assumes
+     that the parallel mesh is fully setup with ghost connectivity
+     etc.
+
+     For now only method 0 (renumber sequentially) is supported
+
+     Eventually, one could precompute some global IDs and just send it
+     to this routine (NOT IMPLEMENTED). Cannot use mtype = MALLTYPE for
+     preassigned GIDs
+
+     Author(s): Rao Garimella
+  */
+
+  int MESH_Renumber_EntityGlobalIDs(Mesh_ptr mesh, MType mtype, int method,
+                                    int *preassigned_gids, MSTK_Comm comm);
+  
+  int MESH_Renumber_GlobalIDs(Mesh_ptr mesh, MType mtype, int method,
+                              int *preassigned_gids, MSTK_Comm comm) {
+    if (preassigned_gids) {
+      MSTK_Report("MESH_Renumber_GlobalIDs",
+                  "Renumbering according to pre-assigned numbering not yet implemented",
+                  MSTK_ERROR);
+    } else {
+      if (MESH_Num_Vertices(mesh) && (mtype == MVERTEX || mtype == MALLTYPE))
+        MESH_Renumber_EntityGlobalIDs(mesh, MVERTEX, method, NULL, comm);
+      if (MESH_Num_Edges(mesh) && (mtype == MEDGE || mtype == MALLTYPE))
+        MESH_Renumber_EntityGlobalIDs(mesh, MEDGE, method, NULL, comm);
+      if (MESH_Num_Faces(mesh) && (mtype == MFACE || mtype == MALLTYPE))
+        MESH_Renumber_EntityGlobalIDs(mesh, MFACE, method, NULL, comm);
+      if (MESH_Num_Regions(mesh) && (mtype == MREGION || mtype == MALLTYPE))
+        MESH_Renumber_EntityGlobalIDs(mesh, MREGION, method, NULL, comm);
+    }
+
+    return 1;
+  }
+  
+
+  int MESH_Renumber_EntityGlobalIDs(Mesh_ptr mesh, MType mtype,
+                                    int method, int *preassigned_gids,
+                                    MSTK_Comm comm) {
+    int i;
+
+    if (method != 0) {
+      MSTK_Report("MESH_Renumber_EntityGlobalIDs",
+                  "Chosen renumbering scheme not implemented", MSTK_ERROR);
+      return 0;
+    }
+    if (mtype == MALLTYPE) {
+      MSTK_Report("MESH_Renumber_EntityGlobalIDs",
+                  "Cannot call this routine for MALLTYPE", MSTK_ERROR);
+      return 0;
+    }
+
+    MAttrib_ptr tmpatt = MAttrib_New(mesh, "tmpatt_renumber", INT, mtype);
+ 
+    int nproc, rank;
+    MPI_Comm_size(comm, &nproc);
+    MPI_Comm_rank(comm, &rank);
+
+    int idx = 0, nowned = 0;
+    MEntity_ptr ment;
+    switch (mtype) {
+      case MVERTEX:
+        while ((ment = MESH_Next_Vertex(mesh, &idx)))
+          if (MV_PType(ment) != PGHOST)
+            nowned++;
+        break;
+      case MEDGE:
+        while ((ment = MESH_Next_Edge(mesh, &idx)))
+          if (ME_PType(ment) != PGHOST)
+            nowned++;
+        break;
+      case MFACE:
+        while ((ment = MESH_Next_Face(mesh, &idx)))
+          if (MF_PType(ment) != PGHOST)
+            nowned++;
+        break;
+      case MREGION:
+        while ((ment = MESH_Next_Region(mesh, &idx)))
+          if (MR_PType(ment) != PGHOST)
+            nowned++;
+        break;
+      default: {}
+    }
+
+    /* Gather the number of entities on every processor */
+
+    int *nowned_all = NULL;
+    if (rank == 0)
+      nowned_all = (int *) calloc(nproc, sizeof(int));
+
+    MPI_Gather(&nowned, 1, MPI_INT, nowned_all, 1, MPI_INT, 0, comm);
+
+    int *offset_all = NULL;
+    if (rank == 0) {      
+      offset_all = (int *) malloc(nproc*sizeof(int));
+      offset_all[0] = 0;
+      int p;
+      for (p = 1; p < nproc; p++)
+        offset_all[p] = offset_all[p-1] + nowned_all[p-1];
+    }
+
+    int offset = 0;
+    MPI_Scatter(offset_all, 1, MPI_INT, &offset, 1, MPI_INT, 0, comm);
+
+    /* At this point if we had different methods for renumbering the
+     * global set of entities, we would generate a Global ID map. For
+     * now this is just a sequential map (method 0) */
+
+    int *new_index = (int *) malloc(nowned*sizeof(int));
+    if (method == 0) {
+      for (i = 0; i < nowned; i++)
+        new_index[i] = i+1;
+    }
+
+    /* Now assign global IDs to the entities */
+    int new_gid;
+    idx = 0; i = 0;
+    switch (mtype) {
+      case MVERTEX:
+        while ((ment = MESH_Next_Vertex(mesh, &idx)))
+          if (MV_PType(ment) != PGHOST) {
+            new_gid = offset + new_index[i];
+            MEnt_Set_AttVal(ment, tmpatt, new_gid, 0.0, NULL);
+            i++;
+          }
+        break;
+      case MEDGE:
+        while ((ment = MESH_Next_Edge(mesh, &idx)))
+          if (ME_PType(ment) != PGHOST) {
+            new_gid = offset + new_index[i];
+            MEnt_Set_AttVal(ment, tmpatt, new_gid, 0.0, NULL);
+            i++;
+          }
+        break;
+      case MFACE:
+        while ((ment = MESH_Next_Face(mesh, &idx)))
+          if (MF_PType(ment) != PGHOST) {
+            new_gid = offset + new_index[i];
+            MEnt_Set_AttVal(ment, tmpatt, new_gid, 0.0, NULL);
+            i++;
+          }
+        break;
+      case MREGION:
+        while ((ment = MESH_Next_Region(mesh, &idx)))
+          if (MR_PType(ment) != PGHOST) {
+            new_gid = offset + new_index[i];
+            MEnt_Set_AttVal(ment, tmpatt, new_gid, 0.0, NULL);
+            i++;
+          }
+        break;
+      default: {}
+    }
+
+    /* Now exchange the attribute across processors */
+    MESH_Update1Attribute(mesh, tmpatt, comm);
+
+    /* Now assign global IDs of the entities based on the values of
+     * the gidatt attribute */
+    idx = 0;
+    double rval;
+    void *pval;
+    switch (mtype) {
+      case MVERTEX:
+        while ((ment = MESH_Next_Vertex(mesh, &idx))) {
+          MEnt_Get_AttVal(ment, tmpatt, &new_gid, &rval, &pval);
+          MV_Set_GlobalID(ment, new_gid);
+        }
+        break;
+      case MEDGE:
+        while ((ment = MESH_Next_Edge(mesh, &idx))) {
+          MEnt_Get_AttVal(ment, tmpatt, &new_gid, &rval, &pval);
+          ME_Set_GlobalID(ment, new_gid);
+        }
+        break;
+      case MFACE:
+        while ((ment = MESH_Next_Face(mesh, &idx))) {
+          MEnt_Get_AttVal(ment, tmpatt, &new_gid, &rval, &pval);
+          MF_Set_GlobalID(ment, new_gid);
+        }
+        break;
+      case MREGION:
+        while ((ment = MESH_Next_Region(mesh, &idx))) {
+          MEnt_Get_AttVal(ment, tmpatt, &new_gid, &rval, &pval);
+          MR_Set_GlobalID(ment, new_gid);
+        }
+        break;
+      default: {}
+    }
+
+    free(nowned_all);
+    free(offset_all);
+
+    MAttrib_Delete(tmpatt);
+
+    return 1;
+  }
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/par/MESH_Update1Attribute.c
+++ b/src/par/MESH_Update1Attribute.c
@@ -293,8 +293,11 @@ extern "C" {
 			   sizeof(int),
 			   compareINT);
 
-      if (loc == NULL)
-        MSTK_Report("MESH_UpdateAttr","Cannot find global ID in list",MSTK_ERROR);
+      if (loc == NULL) {
+        char msg[256];
+        sprintf(msg, "Cannot find entity of type %d with global ID %d in list on proc %d", mtype, global_id, myrank);
+        MSTK_Report("MESH_UpdateAttr",msg,MSTK_ERROR);
+      }
 
       /* get the index */
       i = (int)(loc - &list_info_recv[0]);

--- a/unittests/parallel/4proc/Test_RenumberGlobalIDs.cc
+++ b/unittests/parallel/4proc/Test_RenumberGlobalIDs.cc
@@ -1,0 +1,173 @@
+#include <UnitTest++.h>
+
+#include "../../../include/MSTK.h"
+#include "../../../include/MSTK_private.h"
+#include <vector>
+#include <algorithm>
+
+SUITE(Parallel) {
+TEST(RenumberGIDs_Dist) {
+  Mesh_ptr mesh;
+  char filename[256];
+  int nproc, rank;
+  MVertex_ptr mv;
+  MEdge_ptr me;
+  MFace_ptr mf;
+  int dim, idx;
+
+  MSTK_Init();
+
+  MSTK_Comm comm = MPI_COMM_WORLD;
+  MPI_Comm_size(comm,&nproc);
+  MPI_Comm_rank(comm,&rank);
+
+  Mesh_ptr mesh0;
+  if (rank == 0) {
+    mesh0 = MESH_New(UNKNOWN_REP);
+
+    sprintf(filename,"parallel/4proc/quad6x5.mstk");
+    MESH_InitFromFile(mesh0, filename, comm);
+  }
+
+//  DebugWait=1;
+//  while (DebugWait);
+
+  int ring = 1; /* One ring ghosts */
+  int with_attr = 1; /* Do allow exchange of attributes */
+  int del_inmesh = 1; /* delete input mesh after partitioning */
+  int method;
+
+#if defined (_MSTK_HAVE_METIS)
+  method = 0;
+#elif defined (_MSTK_HAVE_ZOLTAN)
+  method = 1;
+#else
+  fprintf(stderr,"Cannot find partitioner\n");
+  status = 0;
+  CHECK(status);
+#endif
+
+  dim = 2;
+  mesh = NULL;
+  MSTK_Mesh_Distribute(mesh0, &mesh, &dim, ring, with_attr, method, 
+		       del_inmesh, comm);
+
+
+  // Assign some random global IDs to the entities
+  srand(time(NULL));
+
+  idx = 0;
+  while ((mv = MESH_Next_Vertex(mesh, &idx)))
+    MV_Set_GlobalID(mv, 25*MV_GlobalID(mv));
+
+  idx = 0;
+  while ((me = MESH_Next_Edge(mesh, &idx)))
+    ME_Set_GlobalID(me, 25*ME_GlobalID(me));
+
+  idx = 0;
+  while ((mf = MESH_Next_Face(mesh, &idx)))
+    MF_Set_GlobalID(mf, 25*MF_GlobalID(mf));
+
+
+  // Verify that the global IDs are discontinuous
+
+  std::vector<int> vgids, egids, fgids;
+  idx = 0;
+  while ((mv = MESH_Next_Vertex(mesh, &idx)))
+    if (MV_PType(mv) != PGHOST)
+      vgids.push_back(MV_GlobalID(mv));
+  std::sort(vgids.begin(), vgids.end());
+  idx = 0;
+  while ((me = MESH_Next_Edge(mesh, &idx)))
+    if (ME_PType(me) != PGHOST)
+      egids.push_back(ME_GlobalID(me));
+  std::sort(egids.begin(), egids.end());
+  idx = 0;
+  while ((mf = MESH_Next_Face(mesh, &idx)))
+    if (MF_PType(mf) != PGHOST)
+      fgids.push_back(MF_GlobalID(mf));
+  std::sort(fgids.begin(), fgids.end());
+
+  bool vjump_found = false;
+  for (int i = 0; i < vgids.size()-1; i++)
+    if (vgids[i] != vgids[i+1]-1) {
+      vjump_found = true;
+      break;
+    }
+  bool ejump_found = false;
+  for (int i = 0; i < egids.size()-1; i++)
+    if (egids[i] != egids[i+1]-1) {
+      ejump_found = true;
+      break;
+    }
+  bool fjump_found = false;
+  for (int i = 0; i < fgids.size()-1; i++)
+    if (fgids[i] != fgids[i+1]-1) {
+      fjump_found = true;
+      break;
+    }
+
+  CHECK(vjump_found);
+  CHECK(ejump_found);
+  CHECK(fjump_found);
+
+  // Call the renumbering routine
+  
+  MESH_Renumber_GlobalIDs(mesh, MALLTYPE, 0, NULL, comm);
+
+
+  // Now verify that there are NO jumps in global IDs
+  vgids.clear();
+  idx = 0;
+  while ((mv = MESH_Next_Vertex(mesh, &idx)))
+    if (MV_PType(mv) != PGHOST)
+      vgids.push_back(MV_GlobalID(mv));
+  std::sort(vgids.begin(), vgids.end());
+
+  vjump_found = false;
+  for (int i = 0; i < vgids.size()-1; i++)
+    if (vgids[i] != vgids[i+1]-1) {
+      vjump_found = true;
+      std::cout << "Vjump - (" << i << ", " << vgids[i] << ")  (" << i+1 << ", "
+                << vgids[i+1] << ")\n";
+      break;
+    }
+  CHECK(!vjump_found);
+
+  egids.clear();
+  idx = 0;
+  while ((me = MESH_Next_Edge(mesh, &idx)))
+    if (ME_PType(me) != PGHOST)
+      egids.push_back(ME_GlobalID(me));
+  std::sort(egids.begin(), egids.end());
+
+  ejump_found = false;
+  for (int i = 0; i < egids.size()-1; i++)
+    if (egids[i] != egids[i+1]-1) {
+      ejump_found = true;
+      std::cout << "Ejump - (" << i << ", " << egids[i] << ")  (" << i+1 << ", "
+                << egids[i+1] << ")\n";
+      break;
+    }
+  CHECK(!ejump_found);
+
+  fgids.clear();
+  idx = 0;
+  while ((mf = MESH_Next_Face(mesh, &idx)))
+    if (MF_PType(mf) != PGHOST)
+      fgids.push_back(MF_GlobalID(mf));
+  std::sort(fgids.begin(), fgids.end());
+
+  fjump_found = false;
+  for (int i = 0; i < fgids.size()-1; i++)
+    if (fgids[i] != fgids[i+1]-1) {
+      fjump_found = true;
+      std::cout << "Fjump - (" << i << ", " << fgids[i] << ")  (" << i+1 << ", "
+                << fgids[i+1] << ")\n";
+      break;
+    }
+  CHECK(!fjump_found);
+
+  return;
+}
+}


### PR DESCRIPTION
When we modify the mesh, the global IDs of entities on a partition can become discontinous. Added routine to reassign global IDs, so that they are continuous in each partition and continuous across partition. For now the renumbering is just sequential. In the future, we will reassign Global IDs based on some criterion such as bandwidth reduction.