### PR TITLE
Expanded ME_Collapse arguments and fix for bugs in parallel machinery in meshes that have been modified

### DIFF
--- a/include/MSTK.h
+++ b/include/MSTK.h
@@ -345,6 +345,7 @@ void MSTK_Init(void);
   void        MV_RegionIDs(MVertex_ptr mvertex, int *nvr, int *vregionids);
 
   int         MV_GlobalID(MVertex_ptr v);
+  void        MV_Set_GlobalID(MVertex_ptr v, int gid);  /* ** CAUTION!! ** */
 
   PType       MV_PType(MVertex_ptr v);    /* PINTERIOR, PGHOST, POVERLAP */
   int         MV_OnParBoundary(MVertex_ptr v); 
@@ -397,6 +398,7 @@ void MSTK_Init(void);
   void        ME_UnLock(MEdge_ptr e);
 
   int         ME_GlobalID(MEdge_ptr e);
+  void        ME_Set_GlobalID(MEdge_ptr e, int gid);  /* ** CAUTION!! ** */
 
   PType       ME_PType(MEdge_ptr e);
   int         ME_OnParBoundary(MEdge_ptr e);
@@ -470,6 +472,7 @@ void MSTK_Init(void);
   void        MF_UnLock(MFace_ptr f);
 
   int         MF_GlobalID(MFace_ptr f);
+  void        MF_Set_GlobalID(MFace_ptr f, int gid);  /* ** CAUTION!! ** */
 
   PType       MF_PType(MFace_ptr f);  
   int         MF_OnParBoundary(MFace_ptr f);
@@ -549,6 +552,7 @@ void MSTK_Init(void);
   void        MR_Coords(MRegion_ptr mregion, int *n, double (*xyz)[3]);
 
   int         MR_GlobalID(MRegion_ptr r);
+  void        MR_Set_GlobalID(MRegion_ptr r, int gid);  /* ** CAUTION!! ** */
 
   PType       MR_PType(MRegion_ptr r);  
   int         MR_MasterParID(MRegion_ptr r);
@@ -601,6 +605,7 @@ void MSTK_Init(void);
 
 
   int         MEnt_GlobalID(MEntity_ptr ent);
+  void        MEnt_Set_GlobalID(MEntity_ptr ent, int gid);  /* caution */
 
   PType       MEnt_PType(MEntity_ptr ent);
   int         MEnt_OnParBoundary(MEntity_ptr ent);

--- a/include/MSTK.h
+++ b/include/MSTK.h
@@ -750,8 +750,14 @@ void MSTK_Init(void);
 
   /* collapse out edge and delete any faces and regions connected to it */
   /* See MVs_Merge for meaning of topoflag                              */
+  /* deleted_entities contains a list of all entities deleted due to    */
+  /* this operation. merged_entity_pairs contains info about merged     */
+  /* entities by storing the deleted and kept entity in each merged pair*/
+  /* (in that order)                                                    */
+
   MVertex_ptr ME_Collapse(MEdge_ptr e, MVertex_ptr ovkeep, int topoflag,
-                          List_ptr *deleted_entities);
+                          List_ptr *deleted_entities,
+                          List_ptr *merged_entity_pairs);
 
   /* Merge faces f1 and f2 - f2 is deleted                      */
   /* See MVs_Merge for meaning of topoflag                      */

--- a/include/MSTK_private.h
+++ b/include/MSTK_private.h
@@ -259,27 +259,22 @@ typedef enum MDelType {MDELREGION=-40, MDELFACE=-30, MDELEDGE=-20, MDELVERTEX=-1
   void  MV_Flag_OnParBoundary(MVertex_ptr v);
   void  MV_Unflag_OnParBoundary(MVertex_ptr v);
   void  MV_Set_MasterParID(MVertex_ptr v, int masterpartid);
-  void  MV_Set_GlobalID(MVertex_ptr v, int globalid);
 
   void  ME_Set_PType(MEdge_ptr e, PType ptype);
   void  ME_Flag_OnParBoundary(MEdge_ptr v);
   void  ME_Unflag_OnParBoundary(MEdge_ptr v);
   void  ME_Set_MasterParID(MEdge_ptr e, int masterparid);
-  void  ME_Set_GlobalID(MEdge_ptr e, int globalid);
 
   void  MF_Set_PType(MFace_ptr f, PType ptype);
   void  MF_Flag_OnParBoundary(MFace_ptr v);
   void  MF_Unflag_OnParBoundary(MFace_ptr v);
   void  MF_Set_MasterParID(MFace_ptr f, int masterpartid);
-  void  MF_Set_GlobalID(MFace_ptr f, int globalid);
 
   void  MR_Set_PType(MRegion_ptr r, PType ptype);
   void  MR_Set_MasterParID(MRegion_ptr r, int masterpartid);
-  void  MR_Set_GlobalID(MRegion_ptr r, int globalid);
 
   void  MEnt_Set_PType(MEntity_ptr ent, PType ptype);
   void  MEnt_Set_MasterParID(MEntity_ptr ent, int masterpartid);
-  void  MEnt_Set_GlobalID(MEntity_ptr ent, int globalid);
 
 
   void         MESH_Set_Prtn(Mesh_ptr mesh, unsigned int partition, 

--- a/src/base/MSet.c
+++ b/src/base/MSet.c
@@ -106,7 +106,7 @@ extern "C" {
   }
 
   int         MSet_Locate(MSet_ptr set, void *entry) {
-    return List_Contains(set->entlist, entry);
+    return List_Locate(set->entlist, entry);
   }
 
   void       *MSet_Entry(MSet_ptr set, int i) {

--- a/src/base/Mesh.c
+++ b/src/base/Mesh.c
@@ -1309,21 +1309,25 @@ void MESH_Enable_GlobalIDSearch(Mesh_ptr mesh) {
 
   if (mesh->nv && !mesh->gid_sorted_mvlist) {
     mesh->gid_sorted_mvlist = List_Copy(mesh->mvertex);
+    List_Compress(mesh->gid_sorted_mvlist);  // can't sort list with gaps
     List_Sort(mesh->gid_sorted_mvlist,mesh->nv,sizeof(MVertex_ptr),compareGlobalID);
   }
 
   if (mesh->ne && !mesh->gid_sorted_melist) {
     mesh->gid_sorted_melist = List_Copy(mesh->medge);
+    List_Compress(mesh->gid_sorted_melist);
     List_Sort(mesh->gid_sorted_melist,mesh->ne,sizeof(MEdge_ptr),compareGlobalID);
   }
 
   if (mesh->nf && !mesh->gid_sorted_mflist) {
     mesh->gid_sorted_mflist = List_Copy(mesh->mface);
+    List_Compress(mesh->gid_sorted_mflist);
     List_Sort(mesh->gid_sorted_mflist,mesh->nf,sizeof(MFace_ptr),compareGlobalID);
   }
 
   if (mesh->nr && !mesh->gid_sorted_mrlist) {
     mesh->gid_sorted_mrlist = List_Copy(mesh->mregion);
+    List_Compress(mesh->gid_sorted_mrlist);
     List_Sort(mesh->gid_sorted_mrlist,mesh->nr,sizeof(MRegion_ptr),compareGlobalID);
   }
 
@@ -1447,23 +1451,39 @@ MEntity_ptr MESH_EntityFromGlobalID(Mesh_ptr mesh, int mtype, int id) {
 int MESH_Sort_GhostLists(Mesh_ptr mesh, 
                          int (*compfunc)(const void*, const void*)) {
 
-  if (mesh->ghvertex)
+  if (mesh->ghvertex) {
+    List_Compress(mesh->ghvertex);  /* cannot sort list with gaps - no cost if no gaps */
     List_Sort(mesh->ghvertex,List_Num_Entries(mesh->ghvertex),sizeof(MVertex_ptr),compfunc);
-  if (mesh->ghedge)
+  }
+  if (mesh->ghedge) {
+    List_Compress(mesh->ghedge);
     List_Sort(mesh->ghedge,List_Num_Entries(mesh->ghedge),sizeof(MEdge_ptr),compfunc);
-  if (mesh->ghface)
-      List_Sort(mesh->ghface,List_Num_Entries(mesh->ghface),sizeof(MFace_ptr),compfunc);
-  if (mesh->ghregion)
-      List_Sort(mesh->ghregion,List_Num_Entries(mesh->ghregion),sizeof(MRegion_ptr),compfunc);
+  }
+  if (mesh->ghface) {
+    List_Compress(mesh->ghface);
+    List_Sort(mesh->ghface,List_Num_Entries(mesh->ghface),sizeof(MFace_ptr),compfunc);
+  }
+  if (mesh->ghregion) {
+    List_Compress(mesh->ghregion);
+    List_Sort(mesh->ghregion,List_Num_Entries(mesh->ghregion),sizeof(MRegion_ptr),compfunc);
+  }
 
-  if (mesh->ovvertex)
+  if (mesh->ovvertex) {
+    List_Compress(mesh->ovvertex);
     List_Sort(mesh->ovvertex,List_Num_Entries(mesh->ovvertex),sizeof(MVertex_ptr),compfunc);
-  if (mesh->ovedge)
+  }
+  if (mesh->ovedge) {
+    List_Compress(mesh->ovedge);
     List_Sort(mesh->ovedge,List_Num_Entries(mesh->ovedge),sizeof(MEdge_ptr),compfunc);
-  if (mesh->ovface)
-      List_Sort(mesh->ovface,List_Num_Entries(mesh->ovface),sizeof(MFace_ptr),compfunc);
-  if (mesh->ovregion)
-      List_Sort(mesh->ovregion,List_Num_Entries(mesh->ovregion),sizeof(MRegion_ptr),compfunc);
+  }
+  if (mesh->ovface) {
+    List_Compress(mesh->ovface);
+    List_Sort(mesh->ovface,List_Num_Entries(mesh->ovface),sizeof(MFace_ptr),compfunc);
+  }
+  if (mesh->ovregion) {
+    List_Compress(mesh->ovregion);
+    List_Sort(mesh->ovregion,List_Num_Entries(mesh->ovregion),sizeof(MRegion_ptr),compfunc);
+  }
 
   return 1;
 }

--- a/src/base/Mesh.c
+++ b/src/base/Mesh.c
@@ -1996,6 +1996,8 @@ void MESH_Rem_GhostVertex(Mesh_ptr mesh, MVertex_ptr v) {
   if (!fnd)
     MSTK_Report("MESH_Rem_GhostVertex","Vertex not found in mesh vertex list",MSTK_FATAL);
 
+  mesh->nv = List_Num_Entries(mesh->mvertex);
+
   fnd = List_RemSorted(mesh->ghvertex,v,&(MV_GlobalID));
   if (!fnd)
     MSTK_Report("MESH_Rem_GhostVertex","Vertex not found in ghost vertex list",MSTK_FATAL);
@@ -2030,6 +2032,8 @@ void MESH_Rem_GhostEdge(Mesh_ptr mesh, MEdge_ptr e) {
 
   if (!fnd)
     MSTK_Report("MESH_Rem_GhostEdge","Edge not found in mesh edge list",MSTK_FATAL);
+
+  mesh->ne = List_Num_Entries(mesh->medge);
 
   fnd = List_RemSorted(mesh->ghedge,e,&(ME_GlobalID));
   if (!fnd)
@@ -2066,6 +2070,8 @@ void MESH_Rem_GhostFace(Mesh_ptr mesh, MFace_ptr f){
   if (!fnd)
     MSTK_Report("MESH_Rem_Face","Face not found in mesh face list",MSTK_FATAL);
 
+  mesh->nf = List_Num_Entries(mesh->mface);
+
   fnd = List_RemSorted(mesh->ghface,f,&(MF_GlobalID));
   if (!fnd)
     MSTK_Report("MESH_Rem_Face","Face not found in ghost list",MSTK_FATAL);
@@ -2099,6 +2105,8 @@ void MESH_Rem_GhostRegion(Mesh_ptr mesh, MRegion_ptr r){
 
   if (!fnd)
     MSTK_Report("MESH_Rem_GhostRegion","Region not found in mesh region list",MSTK_FATAL);
+
+  mesh->nr = List_Num_Entries(mesh->mregion);
 
   fnd = List_RemSorted(mesh->ghregion,r,&(MR_GlobalID));
   if (!fnd)

--- a/src/par/MESH_Parallel_Check.c
+++ b/src/par/MESH_Parallel_Check.c
@@ -143,7 +143,7 @@ int MESH_Parallel_Check_VertexGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Co
 
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    mv = MESH_Vertex(mesh, ov_list[nov + iloc]-1);  /* get the vertex on current mesh */
+	    mv = MESH_VertexFromID(mesh, ov_list[nov + iloc]);  /* get the vertex on current mesh */
 	    gdim = (recv_list_vertex[3*j] & 7);
 	    gid = (recv_list_vertex[3*j] >> 3);
 	    ptype = (recv_list_vertex[3*j+1] & 3);
@@ -245,7 +245,7 @@ int MESH_Parallel_Check_VertexGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Co
 
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    mv = MESH_Vertex(mesh, ov_list[nov + iloc]-1);  /* get the vertex on current mesh */
+	    mv = MESH_VertexFromID(mesh, ov_list[nov + iloc]);  /* get the vertex on current mesh */
 	    gdim = (recv_list_vertex[3*j] & 7);
 	    gid = (recv_list_vertex[3*j] >> 3);
 	    ptype = (recv_list_vertex[3*j+1] & 3);
@@ -378,7 +378,7 @@ int MESH_Parallel_Check_EdgeGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Comm
 	  }
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    me = MESH_Edge(mesh, ov_list[noe + iloc]-1);  /* get the edge on current mesh */
+	    me = MESH_EdgeFromID(mesh, ov_list[noe + iloc]);  /* get the edge on current mesh */
 	    gdim = (recv_list_edge[5*j+2] & 7);
 	    gid = (recv_list_edge[5*j+2] >> 3);
 	    ptype = (recv_list_edge[5*j+3] & 3);
@@ -470,7 +470,7 @@ int MESH_Parallel_Check_EdgeGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Comm
 	  }
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    me = MESH_Edge(mesh, ov_list[noe + iloc]-1);  /* get the edge on current mesh */
+	    me = MESH_EdgeFromID(mesh, ov_list[noe + iloc]);  /* get the edge on current mesh */
 	    gdim = (recv_list_edge[5*j+2] & 7);
 	    gid = (recv_list_edge[5*j+2] >> 3);
 	    ptype = (recv_list_edge[5*j+3] & 3);
@@ -602,7 +602,7 @@ int MESH_Parallel_Check_FaceGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Comm
 	  }
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    mf = MESH_Face(mesh, ov_list[nof + iloc]-1);  /* get the face on current mesh */
+	    mf = MESH_FaceFromID(mesh, ov_list[nof + iloc]);  /* get the face on current mesh */
 	    gdim = (recv_list_face[index_mf+nfe+1] & 7);
 	    gid = (recv_list_face[index_mf+nfe+1] >> 3);
 	    ptype = (recv_list_face[index_mf+nfe+2] & 3);
@@ -697,7 +697,7 @@ int MESH_Parallel_Check_FaceGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Comm
 	  }
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    mf = MESH_Face(mesh, ov_list[nof + iloc]-1);  /* get the face on current mesh */
+	    mf = MESH_FaceFromID(mesh, ov_list[nof + iloc]);  /* get the face on current mesh */
 	    gdim = (recv_list_face[index_mf+nfe+1] & 7);
 	    gid = (recv_list_face[index_mf+nfe+1] >> 3);
 	    ptype = (recv_list_face[index_mf+nfe+2] & 3);
@@ -818,7 +818,7 @@ int MESH_Parallel_Check_RegionGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Co
 	  }
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    mr = MESH_Region(mesh, ov_list[nor + iloc]-1);  /* get the region on current mesh */
+	    mr = MESH_RegionFromID(mesh, ov_list[nor + iloc]);  /* get the region on current mesh */
 	    gdim = (recv_list_region[index_mr+nrf+1] & 7);
 	    gid = (recv_list_region[index_mr+nrf+1] >> 3);
 	    ptype = (recv_list_region[index_mr+nrf+2] & 3);
@@ -912,7 +912,7 @@ int MESH_Parallel_Check_RegionGlobalID(Mesh_ptr mesh, int rank, int num, MSTK_Co
 	  }
 	  if(loc) {                /* vertex found, but other information mismatch */
 	    iloc = (int)(loc - ov_list);
-	    mr = MESH_Region(mesh, ov_list[nor + iloc]-1);  /* get the region on current mesh */
+	    mr = MESH_RegionFromID(mesh, ov_list[nor + iloc]);  /* get the region on current mesh */
 	    gdim = (recv_list_region[index_mr+nrf+1] & 7);
 	    gid = (recv_list_region[index_mr+nrf+1] >> 3);
 	    ptype = (recv_list_region[index_mr+nrf+2] & 3);

--- a/src/par/MESH_Recv_NonVertexEntities.c
+++ b/src/par/MESH_Recv_NonVertexEntities.c
@@ -159,10 +159,10 @@ extern "C" {
 
         ME_Set_GlobalID(me,list_edge[nevs+4]);
         
-        int vid0 = list_edge[nevs]-1;
-        int vid1 = list_edge[nevs+1]-1;
-        ME_Set_Vertex(me,0,MESH_Vertex(mesh,vid0));
-        ME_Set_Vertex(me,1,MESH_Vertex(mesh,vid1));
+        int vid0 = list_edge[nevs];
+        int vid1 = list_edge[nevs+1];
+        ME_Set_Vertex(me,0,MESH_VertexFromID(mesh,vid0));
+        ME_Set_Vertex(me,1,MESH_VertexFromID(mesh,vid1));
         nevs += 5;
       }
     }

--- a/src/util/List.c
+++ b/src/util/List.c
@@ -212,6 +212,12 @@ extern "C" {
 
   void List_Sort(List_ptr l, size_t num, size_t size, 
 		 int(*comp)(const void *,const void *)) {
+    int p, ntot, nent, nrem, rem1;
+
+    pvtList_Get_Pars(l,&nent,&p,&nrem,&rem1);
+
+    if (nrem)
+      MSTK_Report("List_Sort", "Cannot sort list with gaps", MSTK_FATAL);
     qsort(List_Entries(l),num,size,comp);
   }
 

--- a/unittests/parallel/4proc/Test_RenumberGlobalIDs.cc
+++ b/unittests/parallel/4proc/Test_RenumberGlobalIDs.cc
@@ -168,6 +168,8 @@ TEST(RenumberGIDs_Dist) {
     }
   CHECK(!fjump_found);
 
+  CHECK(MESH_Parallel_Check(mesh, comm) == 1);
+
   return;
 }
 }


### PR DESCRIPTION
Some parts of the parallel machinery were broken for meshes that had mesh entity deletions and this PR fixes them. Its not a guarantee that everything will work but at least a test in [Amanzi](https://github.com/amanzi/amanzi) that didn't run is fixed.

This PR also includes a new version of ME_Collapse that not only returns the deleted entities but also merged entity pairs - useful for updating global IDs and for updating mesh sets *THIS IS A BACKWARD INCOMPATIBLE CHANGE AND MSTK'S MAJOR VERSION NUMBER WILL BE UPDATED*