### PR TITLE
Changes to make ME_Split work correctly

### DIFF
--- a/src/mod/ME_MultiSplit.c
+++ b/src/mod/ME_MultiSplit.c
@@ -42,7 +42,7 @@ List_ptr ME_MultiSplit(MEdge_ptr esplit, int n, double (*xyz)[3]) {
 
   if (xyz) { /* user specified split coordinates */
     for (i = 1; i <= n; i++)
-      memcpy(vxyz[i],xyz[i],sizeof(double[3]));
+      memcpy(vxyz[i],xyz[i-1],sizeof(double[3]));
   }
   else { /* equispaced split coordinates */
     for (i = 1; i <= n; i++)

--- a/unittests/serial/test_ME_Split.cc
+++ b/unittests/serial/test_ME_Split.cc
@@ -23,7 +23,7 @@ TEST(ME_Split)
   CHECK(MESH_Num_Vertices(mesh) > 0);
   
   idx = 0; ne = 0;
-  while ((me = MESH_Next_Edge(mesh,&idx)) && ne == 2) {
+  while ((me = MESH_Next_Edge(mesh,&idx)) && ne != 2) {
     if (ME_GEntDim(me) == 3) {
       
       /* Get vertices of edge */
@@ -59,6 +59,11 @@ TEST(ME_Split)
 
       vnew = ME_Split(me,xyznew);
       CHECK(vnew);
+
+      /* Check the coordinates of vnew */
+      double vnew_xyz[3];
+      MV_Coords(vnew, vnew_xyz);
+      CHECK_ARRAY_EQUAL(xyznew, vnew_xyz, 3);
 
       velist = MV_Edges(vnew);
       nve = List_Num_Entries(velist);


### PR DESCRIPTION
An error was lurking since at least v 2.25 in ME_MultiSplit and this caused ME_Split to not set the coordinates of the split vertex correctly.

Fixed the bugs in a branch called v_2_25_fixes and cherry picked those commits to the current version 