### PR TITLE
bug fix in false error message

### DIFF
--- a/src/par/FixColumnPartitions.c
+++ b/src/par/FixColumnPartitions.c
@@ -74,7 +74,7 @@ int FixColumnPartitions_UpDownFaces(Mesh_ptr mesh, MRegion_ptr mr, MFace_ptr* up
       found++;
     }
     i++;
-    if (i >= nrf) 
+    if (i >= nrf && found < 2) 
       MSTK_Report("FixColumnPartitions","Mesh is not columnar, can't find both up and down faces.",MSTK_FATAL);
   }
 


### PR DESCRIPTION
In the case that "up" or "down" face is the last face, this matches, increments found to 2, increments i to nrf+1, and then errors.  Alternatively this check could be made at the start of the while loop, without the extra conditional.