### PR TITLE
comparison of coordinates within 1.e-12 is arbitrary, and fails for some examples

### DIFF
--- a/src/par/FixColumnPartitions.c
+++ b/src/par/FixColumnPartitions.c
@@ -94,8 +94,8 @@ int FixColumnPartitions_UpDownFaces(Mesh_ptr mesh, MRegion_ptr mr, MFace_ptr* up
   }
 
   /* ASSERT x,y are the same */
-  if (fabs(upcen[0] - dncen[0]) > 1.e-12 ||
-      fabs(upcen[1] - dncen[1]) > 1.e-12) {
+  if (fabs(upcen[0] - dncen[0])/fmax(fabs(upcen[0]),1.) > 1.e-12 ||
+      fabs(upcen[1] - dncen[1])/fmax(fabs(upcen[1]),1.) > 1.e-12) {
     MSTK_Report("FixColumnPartitions","Mesh is not quite columnar, up and down faces do not align.",MSTK_FATAL);
   }
 


### PR DESCRIPTION
Specifically when the mesh is in UTM (~1e6), then numerical roundoff of differences is > 1.e-12.  This attempts to do a relative norm where reasonable.

I only have an example that breaks this comparison, so I'm not sure if relative norms could/should be used elsewhere?

Sorry for the quick second pull request -- I fixed the one issue and didn't find the second until a different mesh.

