### PR TITLE
Reset cached max IDs after renumbering

### DIFF
--- a/include/MSTK.h
+++ b/include/MSTK.h
@@ -220,7 +220,8 @@ void MSTK_Init(void);
      mtype      = Type of entity to renumber (MVERTEX, MEDGE, MFACE, MREGION
                   or MALLTYPE)
 
-                  WORKS ONLY FOR SERIAL MESHES - See Mesh_RenumberGlobalIDs
+     PER PROCESSOR RENUMBERING ONLY! See Mesh_RenumberGlobalIDs for
+     consistent global ID renumbering of distributed meshes
   */
 
   void        MESH_Renumber(Mesh_ptr mesh, int renum_type, MType mtype);

--- a/include/MSTK_private.h
+++ b/include/MSTK_private.h
@@ -33,6 +33,7 @@ typedef enum MDelType {MDELREGION=-40, MDELFACE=-30, MDELEDGE=-20, MDELVERTEX=-1
 
 /* THIS FILE HAS ADDITIONAL FUNCTIONS THAT THE NORMAL USER NEED NOT SEE */
 
+  void       MESH_Reset_Cached_MaxIDs(Mesh_ptr mesh);
 
   void       MESH_Add_Vertex(Mesh_ptr mesh, MVertex_ptr v);
   void       MESH_Add_Edge(Mesh_ptr mesh, MEdge_ptr e);

--- a/src/base/Mesh.c
+++ b/src/base/Mesh.c
@@ -1098,6 +1098,43 @@ void MESH_Rem_Region(Mesh_ptr mesh, MRegion_ptr r){
   return;
 }    
 
+/* Reset the max IDs of entities cached in the mesh data structure
+   Necessary after MESH has been modified and then renumbered for IDs
+   to be contiguous */
+void  MESH_Reset_Cached_MaxIDs(Mesh_ptr mesh) {
+  MVertex_ptr mv;
+  MEdge_ptr me;
+  MFace_ptr mf;
+  MRegion_ptr mr;
+
+  int idx = 0;
+  int maxid = 0;
+  while ((mv = MESH_Next_Vertex(mesh, &idx)))
+    if (maxid < MV_ID(mv)) maxid = MV_ID(mv);
+  mesh->max_vid = maxid;
+
+  idx = 0;
+  maxid = 0;
+  while ((me = MESH_Next_Edge(mesh, &idx)))
+    if (maxid < ME_ID(me)) maxid = ME_ID(me);
+  mesh->max_eid = maxid;
+
+  idx = 0;
+  maxid = 0;
+  while ((mf = MESH_Next_Face(mesh, &idx)))
+    if (maxid < MF_ID(mf)) maxid = MF_ID(mf);
+  mesh->max_fid = maxid;
+
+  idx = 0;
+  maxid = 0;
+  while ((mr = MESH_Next_Region(mesh, &idx)))
+    if (maxid < MR_ID(mr)) maxid = MR_ID(mr);
+  mesh->max_rid = maxid;
+}
+
+
+
+
 List_ptr   MESH_Vertex_List(Mesh_ptr mesh) {
   return mesh->mvertex;
 }

--- a/src/hilev/MESH_Renumber.c
+++ b/src/hilev/MESH_Renumber.c
@@ -1049,7 +1049,13 @@ void MESH_Renumber(Mesh_ptr mesh, int renum_type, MType mtype) {
   while ((mv = MESH_Next_Vertex(mesh,&idx))) {
     MEnt_Set_AttVal(mv,vidatt,MV_ID(mv),0.0,NULL);
   }
-    
+ 
+
+  /* We have to reset the max IDs stored in the mesh so that we can correctly
+     assign IDs to new entities */
+
+  MESH_Reset_Cached_MaxIDs(mesh);
+
   return;
 }
 

--- a/src/io/MESH_ImportFromExodusII.c
+++ b/src/io/MESH_ImportFromExodusII.c
@@ -49,39 +49,6 @@ extern "C" {
                               MSTK_Comm comm) {
 
   char mesg[256], funcname[32]="MESH_ImportFromExodusII";
-  char title[256], elem_type[256], sidesetname[256], nodesetname[256];
-  char matsetname[256];
-  char **elem_blknames;
-  int i, j, k, k1;
-  int comp_ws = sizeof(double), io_ws = 0;
-  int exoid=0, status;
-  int ndim, nnodes, nelems, nelblock, nnodesets, nsidesets;
-  int nedges, nedge_blk, nfaces, nface_blk, nelemsets;
-  int nedgesets, nfacesets, nnodemaps, nedgemaps, nfacemaps, nelemmaps;
-  int *elem_blk_ids, *connect, *node_map, *elem_map, *nnpe;
-  int nelnodes, neledges, nelfaces;
-  int nelem_i, natts;
-  int *sideset_ids, *ss_elem_list, *ss_side_list, *nodeset_ids, *ns_node_list;
-  int num_nodes_in_set, num_sides_in_set, num_df_in_set;
-
-  double *xvals, *yvals, *zvals, xyz[3];
-  float version;
-
-  int exo_nrf[3] = {4,5,6};
-  int exo_nrfverts[3][6] =
-    {{3,3,3,3,0,0},{4,4,4,3,3,0},{4,4,4,4,4,4}};
-  int exo_rfverts[3][6][4] =
-    {{{0,1,3,-1},{1,2,3,-1},{2,0,3,-1},{2,1,0,-1},{-1,-1,-1,-1},{-1,-1,-1,-1}},
-     {{0,1,4,3},{1,2,5,4},{2,0,3,5},{2,1,0,-1},{3,4,5,-1},{-1,-1,-1,-1}},
-     {{0,1,5,4},{1,2,6,5},{2,3,7,6},{3,0,4,7},{3,2,1,0},{4,5,6,7}}};
-
-  List_ptr fedges, rfaces;
-  MVertex_ptr mv, *fverts, *rverts;
-  MEdge_ptr me;
-  MFace_ptr mf;
-  MRegion_ptr mr;
-  MAttrib_ptr nmapatt=NULL, elblockatt=NULL, nodesetatt=NULL, sidesetatt=NULL;
-  MSet_ptr faceset=NULL, nodeset=NULL, sideset=NULL, matset=NULL;
   int distributed=0;
   
   ex_init_params exopar;

--- a/src/io/MESH_ImportFromNemesisI.c
+++ b/src/io/MESH_ImportFromNemesisI.c
@@ -43,39 +43,6 @@ extern "C" {
   int MESH_ImportFromNemesisI(Mesh_ptr mesh, const char *filename, int *parallel_opts, MSTK_Comm comm) {
 
   char mesg[256], funcname[32]="MESH_ImportFromNemesisI";
-  char title[256], elem_type[256], sidesetname[256], nodesetname[256];
-  char matsetname[256];
-  char **elem_blknames;
-  int i, j, k, k1;
-  int comp_ws = sizeof(double), io_ws = 0;
-  int exoid=0, status;
-  int ndim, nnodes, nelems, nelblock, nnodesets, nsidesets;
-  int nedges, nedge_blk, nfaces, nface_blk, nelemsets;
-  int nedgesets, nfacesets, nnodemaps, nedgemaps, nfacemaps, nelemmaps;
-  int *elem_blk_ids, *connect, *node_map, *elem_map, *nnpe;
-  int nelnodes, neledges, nelfaces;
-  int nelem_i, natts;
-  int *sideset_ids, *ss_elem_list, *ss_side_list, *nodeset_ids, *ns_node_list;
-  int num_nodes_in_set, num_sides_in_set, num_df_in_set;
-
-  double *xvals, *yvals, *zvals, xyz[3];
-  float version;
-
-  int exo_nrf[3] = {4,5,6};
-  int exo_nrfverts[3][6] =
-    {{3,3,3,3,0,0},{4,4,4,3,3,0},{4,4,4,4,4,4}};
-  int exo_rfverts[3][6][4] =
-    {{{0,1,3,-1},{1,2,3,-1},{2,0,3,-1},{2,1,0,-1},{-1,-1,-1,-1},{-1,-1,-1,-1}},
-     {{0,1,4,3},{1,2,5,4},{2,0,3,5},{2,1,0,-1},{3,4,5,-1},{-1,-1,-1,-1}},
-     {{0,1,5,4},{1,2,6,5},{2,3,7,6},{3,0,4,7},{3,2,1,0},{4,5,6,7}}};
-
-  List_ptr fedges, rfaces;
-  MVertex_ptr mv, *fverts, *rverts;
-  MEdge_ptr me;
-  MFace_ptr mf;
-  MRegion_ptr mr;
-  MAttrib_ptr nmapatt=NULL, elblockatt=NULL, nodesetatt=NULL, sidesetatt=NULL;
-  MSet_ptr faceset=NULL, nodeset=NULL, sideset=NULL, matset=NULL;
   int distributed=0;
   
   ex_init_params exopar;


### PR DESCRIPTION
The important change in this PR is to make the Mesh object updated its cached values of max IDs for entities after a mesh renumber. This is important when renumbering follows mesh entity deletion because the gaps in IDs get compressed. Before making this change the internally cached maxid was not being updated to account for ID compression, so any new mesh entities were starting with a much higher ID than the number of such entities in the mesh.

Also, some cosmetic changes.